### PR TITLE
Updated Test-AdminRights for non english systems

### DIFF
--- a/Source/Modules/General.psm1
+++ b/Source/Modules/General.psm1
@@ -103,17 +103,18 @@ Function Test-Numeric
 function Test-AdminRights
 {
     param([string] $Log = '.\Clue.log')
-    [string] $sLine = ''
-    $oOutput = Invoke-Expression -Command 'logman create counter AdminTest1234 -c "\Processor(*)\% Processor Time"'
-    foreach ($sLine in $oOutput)
+
+    $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
+
+    if ($isAdmin)
     {
-        if ($sLine.Contains('command completed successfully'))
-        {
-            $oOutput = Invoke-Expression -Command 'logman delete AdminTest1234'
-            Return $true
-        }
+        Write-Log ('[Test-AdminRights] User has administrator rights') -Log $Log
     }
-    Return $false
+    else
+    {
+         Write-Log ('[Test-AdminRights] User does not have administrator rights') -Log $Log
+    }
+    return $isAdmin
 }
 
 Function Test-OSCompatibility


### PR DESCRIPTION
Test-AdminRights did not work on non english systems. 
Source: Hey Scripting Guy blog.
http://blogs.technet.com/b/heyscriptingguy/archive/2011/05/11/check-for-admin-credentials-in-a-powershell-script.aspx
Now it works on all Windows Versions.